### PR TITLE
fix: correct spelling of "Angeles" in Open Graph meta tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://marian-angeles.com/">
-    <meta property="og:site_name" content="Marian Ángeles Maquillaje Profesional">
+    <meta property="og:site_name" content="Marian Angeles Maquillaje Profesional">
     <!-- Título para compartir en redes sociales (atractivo y claro) -->
     <meta property="og:title" content="Maquillaje Profesional a Domicilio en CDMX | Marian Ángeles">
     <!-- Descripción para compartir (enfocada en conversión) -->


### PR DESCRIPTION
This pull request includes a minor update to the Open Graph metadata in the `index.html` file, correcting the spelling of the site name for better consistency across social sharing platforms.

* Updated the `og:site_name` property in the Open Graph metadata to use "Marian Angeles Maquillaje Profesional" instead of "Marian Ángeles Maquillaje Profesional" for improved consistency.