### PR TITLE
quitar acento

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://marian-angeles.com/">
-    <meta property="og:site_name" content="Marian Ángeles Maquillaje Profesional">
+    <meta property="og:site_name" content="Marian Angeles Maquillaje Profesional">
     <!-- Título para compartir en redes sociales (atractivo y claro) -->
     <meta property="og:title" content="Maquillaje Profesional a Domicilio en CDMX | Marian Ángeles">
     <!-- Descripción para compartir (enfocada en conversión) -->


### PR DESCRIPTION
This pull request contains a minor update to the Open Graph meta tags in the `index.html` file, correcting the spelling of the site name by removing the accent from "Ángeles."