### PR TITLE
feat: enhance Content Security Policy to allow frames from Google Maps

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
     <link rel="stylesheet" href="css/inline-styles.css">
     
     <!-- Content Security Policy (meta) -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; block-all-mixed-content; img-src 'self' https://res.cloudinary.com https: data:; font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com data:; style-src 'self' https://fonts.googleapis.com https://cdnjs.cloudflare.com 'unsafe-inline'; script-src 'self'; connect-src 'self' https://res.cloudinary.com;"> 
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; block-all-mixed-content; img-src 'self' https://res.cloudinary.com https: data:; font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com data:; style-src 'self' https://fonts.googleapis.com https://cdnjs.cloudflare.com 'unsafe-inline'; script-src 'self'; connect-src 'self' https://res.cloudinary.com; frame-src 'self' https://www.google.com https://maps.google.com;"> 
 
     <!-- Critical CSS moved to css/inline-styles.css -->
     


### PR DESCRIPTION
This pull request updates the Content Security Policy (CSP) in the `index.html` file to allow embedding content from Google Maps and Google.com in iframes. This change is important for enabling the use of Google Maps or similar services within the site.

Security policy update:

* Updated the CSP `frame-src` directive to allow iframes from `https://www.google.com` and `https://maps.google.com` in addition to `'self'`, enabling embedding of Google Maps and related content.