### PR TITLE
feat: add Facebook Pixel tracking for enhanced conversion tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,6 +54,24 @@
             gtag('config', 'G-3B4KD8CVW7');
         </script>
 
+        <!-- Meta Pixel Code -->
+        <script>
+        !function(f,b,e,v,n,t,s)
+        {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+        n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+        if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+        n.queue=[];t=b.createElement(e);t.async=!0;
+        t.src=v;s=b.getElementsByTagName(e)[0];
+        s.parentNode.insertBefore(t,s)}(window, document,'script',
+        'https://connect.facebook.net/en_US/fbevents.js');
+        fbq('init', '1367617011301877');
+        fbq('track', 'PageView');
+        </script>
+        <noscript><img height="1" width="1" style="display:none"
+        src="https://www.facebook.com/tr?id=1367617011301877&ev=PageView&noscript=1"
+        /></noscript>
+        <!-- End Meta Pixel Code -->
+
         <!-- Schema.org JSON-LD for LocalBusiness -->
         <script type="application/ld+json">
         {

--- a/js/script.js
+++ b/js/script.js
@@ -25,8 +25,72 @@
     }
 
     // ===================================
+    // FACEBOOK PIXEL TRACKING SYSTEM
+    // Rastreo complementario para conversiones en Facebook
+    // ===================================
+
+    function sendFacebookEvent(eventName, data = {}) {
+        try {
+            if (typeof fbq === 'function') {
+                fbq('track', eventName, data);
+            }
+        } catch (e) {
+            console.debug('Facebook event not sent:', eventName);
+        }
+    }
+
+    // ===================================
+    // UNIFIED TRACKING FUNCTION
+    // Envía eventos a GA4 y Facebook simultáneamente
+    function sendTrackingEvent(eventType, method, label, value = null) {
+        // GA4 parameters
+        const gaParams = {
+            method: method,
+            content_type: 'cta',
+            content_id: label,
+            page_location: location.pathname
+        };
+        if (value !== null) gaParams.value = value;
+
+        // Mapeo de eventos para Facebook Pixel
+        const facebookEventMap = {
+            'generate_lead': {
+                name: 'Lead',
+                data: {
+                    content_name: label,
+                    content_type: 'lead'
+                }
+            },
+            'share': {
+                name: 'Contact',
+                data: {
+                    content_name: label,
+                    content_type: 'social_engagement'
+                }
+            },
+            'select_content': {
+                name: 'FindLocation',
+                data: {
+                    content_name: label,
+                    content_type: 'location'
+                }
+            }
+        };
+
+        // Enviar a GA4
+        sendGtagEvent(eventType, gaParams);
+
+        // Enviar a Facebook Pixel
+        if (facebookEventMap[eventType]) {
+            const fbEvent = facebookEventMap[eventType];
+            sendFacebookEvent(fbEvent.name, fbEvent.data);
+        }
+    }
+
+    // ===================================
     // RASTREO DE ELEMENTOS CON DATA-GTAG-*
     // Sistema genérico que funciona para WhatsApp, redes sociales, CTAs, etc.
+    // Envía eventos a GA4 y Facebook Pixel simultáneamente
     function initGtagTracking() {
         document.addEventListener('click', function (e) {
             const el = e.target.closest && e.target.closest('[data-gtag-event]');
@@ -36,21 +100,9 @@
             const method = el.dataset.gtagMethod || 'link';
             const label = el.dataset.gtagLabel || (el.textContent || '').trim().slice(0, 100);
             const value = el.dataset.gtagValue ? Number(el.dataset.gtagValue) : undefined;
-            const contentType = el.dataset.gtagContentType || 'cta';
-            const contentId = el.dataset.gtagContentId || label;
 
-            const params = {
-                method: method,
-                content_type: contentType,
-                content_id: contentId,
-                link_url: el.href || '',
-                page_location: location.pathname
-            };
-            
-            if (!isNaN(value)) params.value = value;
-
-            // Enviar evento a GA4
-            sendGtagEvent(eventName, params);
+            // Enviar evento a GA4 y Facebook Pixel
+            sendTrackingEvent(eventName, method, label, value);
 
             // Para links externos (no _blank), permitir navegación después del evento
             // Si es _blank, el evento se envía y se abre sin esperar
@@ -312,6 +364,14 @@
         // Show success message
         showNotification('Redirigiendo a WhatsApp...', 'success');
         
+        // Send conversion event to Facebook Pixel
+        sendFacebookEvent('Lead', {
+            content_name: serviceName,
+            content_type: 'service_booking',
+            value: 100, // estimated value
+            currency: 'MXN'
+        });
+        
         // Redirect to WhatsApp
         setTimeout(() => {
             window.open(`https://wa.me/525661430855?text=${whatsappMessage}`, '_blank', 'noopener,noreferrer');
@@ -536,8 +596,20 @@
         // Set initial navbar state
         handleNavbarScroll();
         
-        // Initialize GA4 event tracking system
+        // Initialize GA4 and Facebook Pixel event tracking system
         initGtagTracking();
+        
+        // Track gallery opens for Facebook Pixel
+        if (galleryItems && galleryItems.length > 0) {
+            galleryItems.forEach((item, index) => {
+                item.addEventListener('click', () => {
+                    sendFacebookEvent('ViewContent', {
+                        content_name: 'gallery_item_' + (index + 1),
+                        content_type: 'gallery'
+                    });
+                });
+            });
+        }
     }
 
     // ===================================


### PR DESCRIPTION
This pull request adds Facebook Pixel tracking to the website, integrating it alongside the existing Google Analytics (GA4) system. The main changes include adding Facebook Pixel code to the HTML, updating JavaScript to send events to both GA4 and Facebook Pixel, and enhancing tracking for key user interactions such as WhatsApp conversions and gallery views.

**Tracking integration:**

* Added Facebook Pixel script and noscript tags to `index.html` for pageview tracking.
* Implemented a unified tracking function `sendTrackingEvent` in `js/script.js` to send events to both GA4 and Facebook Pixel, mapping key event types between the platforms. [[1]](diffhunk://#diff-54728521937e00eb49236a8b8da0234bb36b320e2daf746b0447d6cbcee4903aR27-R93) [[2]](diffhunk://#diff-54728521937e00eb49236a8b8da0234bb36b320e2daf746b0447d6cbcee4903aL39-R105)

**Enhanced event tracking:**

* Updated WhatsApp conversion logic to send a 'Lead' event to Facebook Pixel with service details and estimated value.
* Added tracking for gallery item views, sending 'ViewContent' events to Facebook Pixel when users open gallery items.