### PR TITLE
feat: update SEO meta tags to promote 25% off bridal packages

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,8 +6,8 @@
     <meta name="theme-color" content="#1a1a1a">
     
     <!-- SEO Meta Tags -->
-    <title>Maquillaje Profesional a Domicilio CDMX| Marian Angeles | Novias & Eventos</title>
-    <meta name="description" content="Maquillista profesional en CDMX y área metropolitana. Especializada en novias y eventos. Servicio a domicilio — agenda tu cita por WhatsApp.">
+    <title>✨ 25% OFF Novias | Marian Angeles | Maquillaje en CDMX</title>
+    <meta name="description" content="¡Promoción Exclusiva! 25% OFF en paquetes de Novia por tiempo limitado. Maquillista profesional a domicilio en CDMX. Agenda tu cita por WhatsApp.">
     <meta name="keywords" content="maquillaje profesional, makeup artist, maquillaje de novias cdmx, maquillaje social, maquillaje polanco, maquillaje santa fe, maquillaje interlomas, maquilladora profesional cdmx, makeup artist mexico, maquillaje eventos, maquillaje a domicilio cdmx, maquillaje roma norte, maquillaje condesa">
     <meta name="author" content="Marian Angeles">
     <meta name="facebook-domain-verification" content="kuh8zuu32c9kz4i1orlb1blvjhrzxx" />
@@ -22,9 +22,9 @@
     <meta property="og:url" content="https://marian-angeles.com/">
     <meta property="og:site_name" content="Marian Angeles Maquillaje Profesional">
     <!-- Título para compartir en redes sociales (atractivo y claro) -->
-    <meta property="og:title" content="Maquillaje Profesional a Domicilio en CDMX | Marian Ángeles">
+    <meta property="og:title" content="✨ 25% OFF Novias | Marian Angeles Maquillista">
     <!-- Descripción para compartir (enfocada en conversión) -->
-    <meta property="og:description" content="Luce increíble en tu día. Maquillaje para novias y eventos especiales en CDMX. ¡Agenda tu cita y resalta tu belleza!">
+    <meta property="og:description" content="¡Promoción Exclusiva! 25% OFF en paquetes de Novia. Luce increíble en tu gran día con maquillaje profesional a domicilio en CDMX.">
     <!-- Imagen para compartir (dimensiones recomendadas: 1200x630px) -->
     <meta property="og:image" content="https://res.cloudinary.com/lealtix-media/image/upload/f_auto,q_auto,w_1200,h_630,c_fill,g_auto/v1768620729/about-photo_ncah4k.jpg">
     <meta property="og:image:width" content="1200">
@@ -39,8 +39,8 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:url" content="https://marian-angeles.com/">
-    <meta name="twitter:title" content="Marian Angeles | Makeup Artist Profesional en CDMX">
-    <meta name="twitter:description" content="Maquillista profesional en CDMX y área metropolitana. Especializada en novias y eventos. Servicio a domicilio — agenda tu cita por WhatsApp.">
+    <meta name="twitter:title" content="✨ 25% OFF Novias | Marian Angeles Maquillista">
+    <meta name="twitter:description" content="¡Promoción Exclusiva! 25% OFF en paquetes de Novia. Luce increíble en tu gran día con maquillaje profesional a domicilio en CDMX.">
     <meta name="twitter:image" content="https://res.cloudinary.com/lealtix-media/image/upload/f_auto,q_auto,w_1200,h_630,c_fill,g_auto/v1768620729/about-photo_ncah4k.jpg">
     <meta name="twitter:image:alt" content="Marian Angeles — Makeup Artist profesional en CDMX">
     <meta name="twitter:site" content="@marian_angelesmakeup">


### PR DESCRIPTION
This pull request updates the SEO and social media meta tags in `index.html` to highlight a limited-time 25% discount promotion for bridal makeup packages. The changes ensure that the promotion is prominently featured in search results and when the site is shared on social media platforms.

SEO and Meta Tag Updates:

* Updated the `<title>` and `<meta name="description">` tags to promote the 25% OFF bridal package offer, making the promotion more visible in search engine results.
* Revised Open Graph (`og:title` and `og:description`) and Twitter Card (`twitter:title` and `twitter:description`) meta tags to highlight the exclusive 25% discount for brides, ensuring the offer is clear when the site is shared on social media. [[1]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L25-R27) [[2]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L42-R43)