### PR TITLE
feat: update background images in styles and HTML for improved visual…

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -614,7 +614,7 @@ ul {
     align-items: center;
     justify-content: center;
     background: linear-gradient(135deg, var(--color-fondo) 0%, var(--color-nude-base) 100%);
-    background-image: url('../img/hero-bg.jpg');
+    background-image: url('../img/about-photo.jpeg');
     background-size: cover;
     background-position: center;
     background-attachment: fixed;

--- a/index.html
+++ b/index.html
@@ -246,11 +246,10 @@
     
     <!-- Stylesheet -->
     <!-- Preload hero and key images to improve LCP (non-intrusive) -->
-    <link rel="preload" href="img/hero-bg.jpg" as="image" importance="high">
     <link rel="preload" href="https://res.cloudinary.com/lealtix-media/image/upload/f_auto,q_auto,w_800/v1768620729/about-photo_ncah4k.jpg" as="image" importance="low">
         <!-- Critical CSS for hero (inline to reduce LCP render delay) -->
         <style>
-            .hero{position:relative;height:100vh;min-height:700px;display:flex;align-items:center;justify-content:center;background:linear-gradient(135deg,var(--color-fondo,#FFFFFF) 0%,var(--color-nude-base,#F5EBE0) 100%);background-image:url('img/hero-bg.jpg');background-size:cover;background-position:center;overflow:hidden}
+            .hero{position:relative;height:100vh;min-height:700px;display:flex;align-items:center;justify-content:center;background:linear-gradient(135deg,var(--color-fondo,#FFFFFF) 0%,var(--color-nude-base,#F5EBE0) 100%);background-size:cover;background-position:center;overflow:hidden}
             .hero-overlay{position:absolute;inset:0;background:var(--hero-overlay-bg, linear-gradient(135deg,rgba(255,255,255,.85) 0%,rgba(245,235,224,.7) 100%));z-index:1}
             .hero-content{position:relative;z-index:2;text-align:center;color:var(--hero-text-color, #000000);animation:fadeInUp 1s ease}
             .hero-title{display:flex;flex-direction:column;gap:1rem}
@@ -262,7 +261,6 @@
     <link rel="stylesheet" href="css/inline-styles.css?v=2">
     
     <!-- Favicon -->
-    <link rel="icon" type="image/png" href="img/favicon.png">
     <link rel="icon" type="image/svg+xml" href="img/favicon.svg">
 </head>
 <body>


### PR DESCRIPTION
This pull request updates the site's hero section background image and makes minor adjustments to image preloading and favicon usage. The main focus is on removing the old hero background image and related references, streamlining the assets used for improved performance and consistency.

**Hero background image updates:**

* Changed the hero section's background image from `hero-bg.jpg` to `about-photo.jpeg` in `css/styles.css`.
* Removed the `background-image` property from the inline `.hero` CSS in `index.html`, so it now relies on the external stylesheet for the background image.
* Removed the preload link for `hero-bg.jpg` from `index.html` since it's no longer used.

**Favicon update:**

* Removed the PNG favicon reference from `index.html`, leaving only the SVG favicon.… consistency