### PR TITLE
Add service areas section with enhanced styling and responsive design

### DIFF
--- a/index.html
+++ b/index.html
@@ -262,6 +262,238 @@
     <link rel="stylesheet" href="css/styles.min.css?v=1">
     <link rel="stylesheet" href="css/inline-styles.min.css?v=1">
     <link rel="stylesheet" href="css/index-extracted.min.css?v=1">
+    <style>
+        .service-areas {
+            position: relative;
+            padding: 72px 0;
+            background:
+                radial-gradient(circle at top left, rgba(212, 175, 55, 0.12), transparent 32%),
+                radial-gradient(circle at bottom right, rgba(166, 124, 82, 0.14), transparent 28%),
+                linear-gradient(180deg, #fbf5ee 0%, #f3e7d9 100%);
+            color: var(--color-gray);
+            overflow: hidden;
+        }
+
+        .service-areas::before {
+            content: "";
+            position: absolute;
+            inset: 0;
+            background: linear-gradient(90deg, rgba(255, 255, 255, 0.26) 0%, rgba(255, 255, 255, 0) 45%, rgba(255, 255, 255, 0.18) 100%);
+            pointer-events: none;
+        }
+
+        .service-areas .container {
+            position: relative;
+            z-index: 1;
+        }
+
+        .service-areas-shell {
+            max-width: 1140px;
+            margin: 0 auto;
+            padding: 2.75rem;
+            border: 1px solid rgba(166, 124, 82, 0.18);
+            border-radius: 32px;
+            background: rgba(255, 252, 247, 0.72);
+            box-shadow: 0 20px 60px rgba(88, 58, 34, 0.08);
+            backdrop-filter: blur(10px);
+        }
+
+        .service-areas-header {
+            max-width: 720px;
+            margin: 0 auto 2.5rem;
+            text-align: center;
+        }
+
+        .service-areas-kicker {
+            display: inline-block;
+            margin-bottom: 0.85rem;
+            padding: 0.4rem 0.9rem;
+            border-radius: 999px;
+            background: rgba(166, 124, 82, 0.12);
+            color: var(--color-secondary);
+            font-size: 0.8rem;
+            font-weight: 700;
+            letter-spacing: 0.16em;
+            text-transform: uppercase;
+        }
+
+        .service-areas-title {
+            margin-bottom: 0.9rem;
+        }
+
+        .service-areas-copy {
+            margin: 0 auto;
+            max-width: 620px;
+            font-size: 1.02rem;
+            line-height: 1.8;
+            color: #5b5149;
+        }
+
+        .service-areas-guide {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.7rem;
+            margin-top: 1.3rem;
+            padding: 0.9rem 1.35rem;
+            border-radius: 999px;
+            border: 1px solid rgba(166, 124, 82, 0.24);
+            background: rgba(255, 255, 255, 0.78);
+            color: var(--color-primary);
+            font-weight: 600;
+            box-shadow: 0 10px 28px rgba(88, 58, 34, 0.08);
+            transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+        }
+
+        .service-areas-guide:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 14px 34px rgba(88, 58, 34, 0.12);
+            border-color: rgba(166, 124, 82, 0.38);
+        }
+
+        .service-areas-grid {
+            display: grid;
+            grid-template-columns: repeat(3, minmax(0, 1fr));
+            gap: 1.25rem;
+        }
+
+        .service-area-card {
+            display: flex;
+            flex-direction: column;
+            min-height: 100%;
+            padding: 1.6rem;
+            border-radius: 22px;
+            border: 1px solid rgba(166, 124, 82, 0.16);
+            background: linear-gradient(180deg, rgba(255, 255, 255, 0.98) 0%, rgba(252, 245, 236, 0.96) 100%);
+            color: var(--color-primary);
+            box-shadow: 0 14px 32px rgba(92, 64, 41, 0.08);
+            transition: transform 0.28s ease, box-shadow 0.28s ease, border-color 0.28s ease;
+        }
+
+        .service-area-card:hover {
+            transform: translateY(-6px);
+            border-color: rgba(212, 175, 55, 0.5);
+            box-shadow: 0 22px 42px rgba(92, 64, 41, 0.14);
+        }
+
+        .service-area-card__tag {
+            align-self: flex-start;
+            margin-bottom: 1rem;
+            padding: 0.42rem 0.78rem;
+            border-radius: 999px;
+            background: rgba(166, 124, 82, 0.12);
+            color: var(--color-secondary);
+            font-family: var(--font-primary);
+            font-size: 0.74rem;
+            font-weight: 700;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+        }
+
+        .service-area-card__title {
+            margin-bottom: 0.75rem;
+            font-family: var(--font-secondary);
+            font-size: 1.5rem;
+            font-weight: 700;
+            line-height: 1.25;
+            color: var(--color-primary) !important;
+            text-wrap: balance;
+        }
+
+        .service-area-card__description {
+            margin-bottom: 1.35rem;
+            font-family: var(--font-primary);
+            font-size: 1rem;
+            font-weight: 400;
+            color: var(--color-gray) !important;
+            line-height: 1.75;
+            flex-grow: 1;
+        }
+
+        .service-area-card__cta {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.55rem;
+            font-family: var(--font-primary);
+            font-weight: 600;
+            color: var(--color-secondary) !important;
+        }
+
+        .service-area-card__cta i {
+            font-size: 0.82rem;
+            transition: transform 0.25s ease;
+        }
+
+        .service-area-card:hover .service-area-card__cta i {
+            transform: translateX(4px);
+        }
+
+        [data-theme="dark"] .service-areas {
+            background:
+                radial-gradient(circle at top left, rgba(212, 175, 55, 0.14), transparent 34%),
+                radial-gradient(circle at bottom right, rgba(166, 124, 82, 0.18), transparent 30%),
+                linear-gradient(180deg, #231d19 0%, #1a1613 100%);
+        }
+
+        [data-theme="dark"] .service-areas-shell {
+            background: rgba(38, 31, 27, 0.76);
+            border-color: rgba(212, 175, 55, 0.14);
+            box-shadow: 0 20px 60px rgba(0, 0, 0, 0.24);
+        }
+
+        [data-theme="dark"] .service-areas-copy,
+        [data-theme="dark"] .service-area-card__description {
+            color: #d7cfc8;
+        }
+
+        [data-theme="dark"] .service-area-card__title {
+            color: var(--color-primary) !important;
+        }
+
+        [data-theme="dark"] .service-areas-guide,
+        [data-theme="dark"] .service-area-card {
+            background: linear-gradient(180deg, rgba(47, 39, 34, 0.98) 0%, rgba(36, 30, 26, 0.96) 100%);
+            border-color: rgba(212, 175, 55, 0.16);
+            box-shadow: 0 16px 34px rgba(0, 0, 0, 0.24);
+        }
+
+        [data-theme="dark"] .service-area-card__tag {
+            background: rgba(212, 175, 55, 0.14);
+            color: #f0d790;
+        }
+
+        [data-theme="dark"] .service-area-card__cta {
+            color: #e2bf86 !important;
+        }
+
+        @media (max-width: 992px) {
+            .service-areas-grid {
+                grid-template-columns: repeat(2, minmax(0, 1fr));
+            }
+        }
+
+        @media (max-width: 768px) {
+            .service-areas {
+                padding: 56px 0;
+            }
+
+            .service-areas-shell {
+                padding: 2rem 1.35rem;
+                border-radius: 24px;
+            }
+
+            .service-areas-grid {
+                grid-template-columns: 1fr;
+            }
+
+            .service-area-card {
+                padding: 1.35rem;
+            }
+
+            .service-area-card__title {
+                font-size: 1.3rem;
+            }
+        }
+    </style>
     
     <!-- Favicon -->
     <link rel="icon" type="image/svg+xml" href="img/favicon.svg">
@@ -1181,36 +1413,56 @@
     </section>
 
     <!-- Service Areas Section -->
-    <section class="service-areas" id="service-areas" style="padding: 60px 0; background: var(--color-light-gray); color: var(--color-gray);">
+    <section class="service-areas" id="service-areas">
         <div class="container">
-            <div style="max-width: 980px; margin: 0 auto; text-align: center;">
-                <h2 class="section-title" style="margin-bottom: 1.4rem;">Zonas de Servicio</h2>
-                <p style="margin-bottom: 2rem;">
-                    <a href="maquillaje-por-zonas/index.html" style="font-weight: 600; color: var(--color-primary);">Ver guia completa de maquillaje por zonas</a>
-                </p>
-
-                <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 1rem; text-align: left; margin-bottom: 2rem;">
-                    <a href="valle-de-bravo/index.html" style="display:block; text-decoration:none; background:#fff; border:1px solid rgba(166,124,82,.25); border-left:4px solid var(--color-gold); border-radius:10px; padding:1rem; box-shadow:var(--shadow-sm);">
-                        <h3 style="font-family:'Playfair Display', serif; font-size:1.05rem; color:var(--color-primario); margin-bottom:0.45rem;">Maquillaje para bodas en Valle de Bravo</h3>
-                        <p style="font-size:0.9rem; color:#666; line-height:1.55;">Looks de larga duracion para bodas de destino y eventos premium en Valle de Bravo.</p>
-                    </a>
-                    <a href="cuernavaca/index.html" style="display:block; text-decoration:none; background:#fff; border:1px solid rgba(166,124,82,.25); border-left:4px solid var(--color-gold); border-radius:10px; padding:1rem; box-shadow:var(--shadow-sm);">
-                        <h3 style="font-family:'Playfair Display', serif; font-size:1.05rem; color:var(--color-primario); margin-bottom:0.45rem;">Maquillista a domicilio en Cuernavaca</h3>
-                        <p style="font-size:0.9rem; color:#666; line-height:1.55;">Servicio profesional a domicilio para novias, invitadas y eventos sociales.</p>
-                    </a>
-                    <a href="santa-fe/index.html" style="display:block; text-decoration:none; background:#fff; border:1px solid rgba(166,124,82,.25); border-left:4px solid var(--color-gold); border-radius:10px; padding:1rem; box-shadow:var(--shadow-sm);">
-                        <h3 style="font-family:'Playfair Display', serif; font-size:1.05rem; color:var(--color-primario); margin-bottom:0.45rem;">Maquillaje profesional en Santa Fe CDMX</h3>
-                        <p style="font-size:0.9rem; color:#666; line-height:1.55;">Atencion puntual y personalizada para eventos corporativos, sociales y bodas.</p>
+            <div class="service-areas-shell">
+                <div class="service-areas-header">
+                    <span class="service-areas-kicker">Cobertura Premium</span>
+                    <h2 class="section-title service-areas-title">Zonas de Servicio</h2>
+                    <p class="service-areas-copy">Cobertura profesional para novias, invitadas y eventos especiales en destinos clave de CDMX, Estado de México y Morelos, con atención a domicilio y enfoque editorial.</p>
+                    <a class="service-areas-guide" href="maquillaje-por-zonas/index.html">
+                        Ver guía completa de maquillaje por zonas
+                        <i class="fas fa-arrow-right" aria-hidden="true"></i>
                     </a>
                 </div>
 
-                <div style="display:grid; grid-template-columns:repeat(auto-fit,minmax(170px,1fr)); gap:.65rem;">
-                    <a class="track-gtag" data-gtag-event="select_content" data-gtag-method="internal_link" data-gtag-label="seo_zone_metepec" href="metepec/index.html" style="text-decoration:none; color:var(--color-primary); background:var(--color-beige); border:1px solid rgba(166,124,82,.22); border-radius:8px; padding:.65rem .75rem; font-weight:600;">Metepec</a>
-                    <a class="track-gtag" data-gtag-event="select_content" data-gtag-method="internal_link" data-gtag-label="seo_zone_valle" href="valle-de-bravo/index.html" style="text-decoration:none; color:var(--color-primary); background:var(--color-beige); border:1px solid rgba(166,124,82,.22); border-radius:8px; padding:.65rem .75rem; font-weight:600;">Valle de Bravo</a>
-                    <a class="track-gtag" data-gtag-event="select_content" data-gtag-method="internal_link" data-gtag-label="seo_zone_morelos" href="morelos/index.html" style="text-decoration:none; color:var(--color-primary); background:var(--color-beige); border:1px solid rgba(166,124,82,.22); border-radius:8px; padding:.65rem .75rem; font-weight:600;">Morelos</a>
-                    <a class="track-gtag" data-gtag-event="select_content" data-gtag-method="internal_link" data-gtag-label="seo_zone_santafe" href="santa-fe/index.html" style="text-decoration:none; color:var(--color-primary); background:var(--color-beige); border:1px solid rgba(166,124,82,.22); border-radius:8px; padding:.65rem .75rem; font-weight:600;">Santa Fe CDMX</a>
-                    <a class="track-gtag" data-gtag-event="select_content" data-gtag-method="internal_link" data-gtag-label="seo_zone_cuernavaca" href="cuernavaca/index.html" style="text-decoration:none; color:var(--color-primary); background:var(--color-beige); border:1px solid rgba(166,124,82,.22); border-radius:8px; padding:.65rem .75rem; font-weight:600;">Cuernavaca</a>
-                    <a class="track-gtag" data-gtag-event="select_content" data-gtag-method="internal_link" data-gtag-label="seo_zone_tepoztlan" href="tepoztlan/index.html" style="text-decoration:none; color:var(--color-primary); background:var(--color-beige); border:1px solid rgba(166,124,82,.22); border-radius:8px; padding:.65rem .75rem; font-weight:600;">Tepoztlan</a>
+                <div class="service-areas-grid">
+                    <a class="service-area-card track-gtag" data-gtag-event="select_content" data-gtag-method="internal_link" data-gtag-label="seo_zone_valle" href="valle-de-bravo/index.html">
+                        <span class="service-area-card__tag">Bodas de destino</span>
+                        <h3 class="service-area-card__title">Maquillaje para bodas en Valle de Bravo</h3>
+                        <p class="service-area-card__description">Looks de larga duración para ceremonias junto al lago, eventos premium y celebraciones donde cada detalle debe verse impecable.</p>
+                        <span class="service-area-card__cta">Explorar zona <i class="fas fa-arrow-right" aria-hidden="true"></i></span>
+                    </a>
+                    <a class="service-area-card track-gtag" data-gtag-event="select_content" data-gtag-method="internal_link" data-gtag-label="seo_zone_cuernavaca" href="cuernavaca/index.html">
+                        <span class="service-area-card__tag">Servicio a domicilio</span>
+                        <h3 class="service-area-card__title">Maquillista a domicilio en Cuernavaca</h3>
+                        <p class="service-area-card__description">Atención profesional para novias, invitadas y eventos sociales con aplicación HD, preparación de piel y acabado durable.</p>
+                        <span class="service-area-card__cta">Explorar zona <i class="fas fa-arrow-right" aria-hidden="true"></i></span>
+                    </a>
+                    <a class="service-area-card track-gtag" data-gtag-event="select_content" data-gtag-method="internal_link" data-gtag-label="seo_zone_santafe" href="santa-fe/index.html">
+                        <span class="service-area-card__tag">Eventos urbanos</span>
+                        <h3 class="service-area-card__title">Maquillaje profesional en Santa Fe CDMX</h3>
+                        <p class="service-area-card__description">Atención puntual y personalizada para bodas, eventos corporativos y celebraciones sociales con estética sofisticada.</p>
+                        <span class="service-area-card__cta">Explorar zona <i class="fas fa-arrow-right" aria-hidden="true"></i></span>
+                    </a>
+                    <a class="service-area-card track-gtag" data-gtag-event="select_content" data-gtag-method="internal_link" data-gtag-label="seo_zone_metepec" href="metepec/index.html">
+                        <span class="service-area-card__tag">Novias y graduaciones</span>
+                        <h3 class="service-area-card__title">Maquillaje profesional en Metepec</h3>
+                        <p class="service-area-card__description">Servicio a domicilio con looks elegantes, fotogénicos y de larga duración para bodas, graduaciones y eventos sociales.</p>
+                        <span class="service-area-card__cta">Explorar zona <i class="fas fa-arrow-right" aria-hidden="true"></i></span>
+                    </a>
+                    <a class="service-area-card track-gtag" data-gtag-event="select_content" data-gtag-method="internal_link" data-gtag-label="seo_zone_morelos" href="morelos/index.html">
+                        <span class="service-area-card__tag">Haciendas y jardines</span>
+                        <h3 class="service-area-card__title">Maquillaje profesional en Morelos</h3>
+                        <p class="service-area-card__description">Cobertura para bodas y eventos especiales con técnicas de alta duración pensadas para clima cálido, foto y video.</p>
+                        <span class="service-area-card__cta">Explorar zona <i class="fas fa-arrow-right" aria-hidden="true"></i></span>
+                    </a>
+                    <a class="service-area-card track-gtag" data-gtag-event="select_content" data-gtag-method="internal_link" data-gtag-label="seo_zone_tepoztlan" href="tepoztlan/index.html">
+                        <span class="service-area-card__tag">Celebraciones boutique</span>
+                        <h3 class="service-area-card__title">Maquillaje para bodas en Tepoztlan</h3>
+                        <p class="service-area-card__description">Propuesta ideal para bodas de destino en jardín, hoteles boutique y locaciones con estética natural y acabado impecable.</p>
+                        <span class="service-area-card__cta">Explorar zona <i class="fas fa-arrow-right" aria-hidden="true"></i></span>
+                    </a>
                 </div>
             </div>
         </div>

--- a/maquillaje-por-zonas/index.html
+++ b/maquillaje-por-zonas/index.html
@@ -39,7 +39,7 @@
       .zone{background:var(--card);border:1px solid rgba(166,124,82,.2);border-left:4px solid var(--gold);border-radius:var(--r);padding:20px;color:inherit;transition:transform .2s,box-shadow .2s;box-shadow:var(--shadow)}
       .zone:hover{transform:translateY(-3px);box-shadow:0 8px 28px rgba(0,0,0,.14)}
       .zone strong{display:block;font-family:'Playfair Display',serif;font-size:1.05rem;color:var(--dark);margin-bottom:8px}
-      .zone span{font-size:.9rem;color:var(--muted);line-height:1.6}
+      .zone span{display:block;font-size:.9rem;color:var(--muted);line-height:1.6}
       .zone-arrow{display:inline-flex;align-items:center;gap:6px;margin-top:12px;font-size:.8rem;font-weight:700;color:var(--accent);text-transform:uppercase;letter-spacing:.05em}
       .site-footer{margin-top:48px;border-top:1px solid rgba(166,124,82,.2);padding-top:20px;text-align:center;color:var(--muted);font-size:.82rem}
       .site-footer a{color:var(--accent);font-weight:600}


### PR DESCRIPTION
This pull request significantly redesigns the "Zonas de Servicio" (Service Areas) section on the main `index.html` page, introducing a modernized, visually appealing layout with enhanced styling, improved content structure, and better user experience for both light and dark themes. Additionally, a small improvement is made to the display of zone descriptions on the `maquillaje-por-zonas/index.html` page.

**Service Areas Section Redesign and Enhancement:**

* Replaces the previous basic grid and button layout in the Service Areas section with a new card-based design, including a visually rich header, descriptive text, and prominent call-to-action buttons for each service area. Each card now contains a tag, title, description, and an "Explorar zona" CTA, improving clarity and engagement.
* Adds a large set of custom CSS styles directly to `index.html` to support the new Service Areas design, including responsive grid layouts, card hover effects, dark mode support, and improved typography and spacing.

**Minor Style Improvement:**

* Updates the `.zone span` style in `maquillaje-por-zonas/index.html` to display as a block element, ensuring consistent spacing and alignment for zone descriptions.