### PR TITLE
Update promotional text for Hot Sale to focus on bridal services

### DIFF
--- a/index.html
+++ b/index.html
@@ -659,9 +659,9 @@
             <p class="promo-text">
                 <span class="promo-kicker">HOT SALE 🔥</span>
                 <span class="promo-offer">25% DE DESCUENTO</span>
-                <span class="promo-categories">Novias • Graduadas • Quinceañeras • Sociales</span>
+                <span class="promo-categories">Para Novias</span>
             </p>
-            <a href="https://wa.me/525661430855?text=Hola%2C%20me%20interesa%20la%20oferta%20especial%20Hot%20Sale%20de%2025%25%20de%20descuento%20para%20Novias%2C%20Graduadas%2C%20Quincea%C3%B1eras%20y%20Sociales" class="promo-btn track-gtag" data-gtag-event="generate_lead" data-gtag-method="whatsapp" data-gtag-label="promo_bar_reservar" target="_blank" rel="noopener">
+            <a href="https://wa.me/525661430855?text=Hola%20Marian%2C%20me%20interesa%20el%20descuento%20especial%20del%2025%25%20para%20mi%20maquillaje%20de%20novia.%20%C2%BFCu%C3%A1l%20es%20tu%20disponibilidad%3F" class="promo-btn track-gtag" data-gtag-event="generate_lead" data-gtag-method="whatsapp" data-gtag-label="promo_bar_reservar" target="_blank" rel="noopener">
                 Ver ofertas <i class="fab fa-whatsapp"></i>
             </a>
         </div>


### PR DESCRIPTION
This pull request updates the promotional banner in the `index.html` file to focus exclusively on bridal services. The offer categories and WhatsApp link have been adjusted to target brides specifically.

Promo banner changes:

* Changed the promo categories text from "Novias • Graduadas • Quinceañeras • Sociales" to "Para Novias" to focus the promotion on bridal services.
* Updated the WhatsApp link and pre-filled message to address bridal makeup discount inquiries, making the message more relevant for brides.